### PR TITLE
New ci pipeline

### DIFF
--- a/.github/mkdocs/mkdocs.yaml
+++ b/.github/mkdocs/mkdocs.yaml
@@ -1,6 +1,5 @@
+INHERIT: mkdocs-default.yml
 site_name: SciCat Documentation
-docs_dir: ../../docs
-
 
 nav: 
   - Home: index.md
@@ -32,14 +31,3 @@ nav:
 
   - About:
       - about/index.md
-
-theme: material 
-
-plugins:
-  - search
-  - glightbox
-  - section-index
-
-
-extra_css:
-  - custom.css

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,11 +6,12 @@ on:  # yamllint disable-line rule:truthy
       - main
     tags:
       - v*
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: SciCatProject/scicatlive/.github/actions/mkdocs-pages@main
+      - uses: SciCatProject/docs-template/.github/actions/mkdocs-pages@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           push: true


### PR DESCRIPTION
This PR changes the CI pipeline that publishes the documentation to use the new docs-template at: https://github.com/SciCatProject/docs-template.

Changes:
* deleting the original workflow file `mkdocs.yml`and replacing it with `publish-docs.yml` from docs-template.
* Updating the `mkdocs.yml` to inherit the base settings from the docs-template repository. 