### PR TITLE
Fix link format in documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
 # Welcome to SciCat Documentation 
 
 Find [**SciCat USERS Guide**](user-guide/index.md) or [**SciCat Operator's Guide**](operator-guide/index.md).
-Developers can read along the ```READMEs``` in github of the [projects page](https://www.scicatproject.org) and in both guides as well.
+Developers can read along the ```READMEs``` in github of the [projects page]([https://www.scicatproject.org/#repositories]) and in both guides as well.


### PR DESCRIPTION
This fixes issue #29. 