### PR TITLE
docs(backendconfig): document access control group env vars

### DIFF
--- a/docs/backendconfig/authorization/authorization.md
+++ b/docs/backendconfig/authorization/authorization.md
@@ -58,6 +58,31 @@ The permissions in the minimal installation provides a set of user groups which 
 | | Users can view logbook for any datasets| DatasetLogbookReadAny | 
 | | |
 | DELETE_GROUPS | Users whose group is listed here are allowed to delete datasets, origdatablock or datablock | DatasetDeleteAny , DatasetOrigdatablockDeleteAny , DatasetDatablockDeleteAny |
+| | |
+| UPDATE_DATASET_LIFECYCLE_GROUPS | Users of the listed groups can update the lifecycle state fields of a dataset. Authenticated users not in this group (and not in ADMIN_GROUPS) cannot modify lifecycle fields. | DatasetLifecycleUpdate |
+| | |
+| POLICY_GROUPS | Users of the listed groups can create, read, and update policies. Users in ADMIN_GROUPS always have this permission. | Create , Read , Update (Policy) |
+| | |
+| ATTACHMENT_GROUPS | Users of the listed groups can create, read, update, and delete attachments belonging to groups they are a member of. Setting this to "#all" grants all authenticated users these permissions (this is the default). | AttachmentCreateInstance , AttachmentReadInstance , AttachmentUpdateInstance , AttachmentDeleteInstance (for own groups) |
+| | |
+| ATTACHMENT_PRIVILEGED_GROUPS | Users of the listed groups can create attachments for any owner group, and can read, update, and delete attachments belonging to groups they are a member of or that they have access to. | AttachmentCreateInstance (any) , AttachmentReadInstance , AttachmentUpdateInstance , AttachmentDeleteInstance (own/access groups) |
+
+## History Access Groups
+
+Change history (audit log) access is controlled by a separate set of group variables, one per tracked entity type. Users in ADMIN_GROUPS always have access to all history. Other users need their group listed in the relevant variable.
+
+| Configuration Group List | Grants access to history of |
+| ------------------------ | --------------------------- |
+| HISTORY_ACCESS_DATASET_GROUPS | Datasets |
+| HISTORY_ACCESS_PROPOSAL_GROUPS | Proposals |
+| HISTORY_ACCESS_SAMPLE_GROUPS | Samples |
+| HISTORY_ACCESS_INSTRUMENT_GROUPS | Instruments |
+| HISTORY_ACCESS_PUBLISHED_DATA_GROUPS | Published data records |
+| HISTORY_ACCESS_POLICIES_GROUPS | Policies |
+| HISTORY_ACCESS_DATABLOCK_GROUPS | Datablocks |
+| HISTORY_ACCESS_ATTACHMENT_GROUPS | Attachments |
+
+All history access group variables default to `""` (no access for non-admin users). A user only needs to be listed in at least one of these variables to access the history endpoint; access to specific entity types is then controlled per-variable.
 
 ## Subsystems
 - [Datasets](./authorization_datasets.md)

--- a/docs/backendconfig/authorization/authorization_datasets.md
+++ b/docs/backendconfig/authorization/authorization_datasets.md
@@ -1,4 +1,21 @@
 # Datasets Authorization
+
+Datasets authorisation relies on groups defined in the configuration file for the backend:
+
+| Configuration Group List | Description |
+| ------------------------ | ----------- |
+| ADMIN_GROUPS | Users of the listed groups can create, read, modify, and delete any dataset. |
+| | |
+| DELETE_GROUPS | Users of the listed groups can delete any dataset. |
+| | |
+| CREATE_DATASET_GROUPS | Users of the listed groups can create and modify datasets for any of the groups they belong to. At creation time, the system assigns a pid to the new datasets. If the user assigns one, the system will ignore it. |
+| | |
+| CREATE_DATASET_WITH_PID_GROUPS | Users of the listed groups can create and modify datasets for any of the groups they belong to. They are allowed to specify the dataset pid. If they decide not to specify a pid, the system will assign one. |
+| | |
+| CREATE_DATASET_PRIVILEGED_GROUPS | Users of the listed groups can create datasets for any group, but can only modify datasets belonging to one of the groups they belong to. They are allowed to specify pids for new datasets. This setting is suggested for ingestion functional accounts. |
+| | |
+| UPDATE_DATASET_LIFECYCLE_GROUPS | Users of the listed groups can update the lifecycle state fields of a dataset. Authenticated users not in this group (and not in ADMIN_GROUPS) cannot modify lifecycle fields. |
+
 ## CASL ability actions
 This is the list of the permissions methods available for datasets and all their endpoints and more fine-grained instance authorization. 
 

--- a/docs/backendconfig/authorization/authorization_datasets.md
+++ b/docs/backendconfig/authorization/authorization_datasets.md
@@ -51,7 +51,7 @@ This is the list of the permissions methods available for datasets and all their
 - DatasetReadAny
 - DatasetUpdateOwner
 - DatasetUpdateAny
-- DetasetDeleteOwner
+- DatasetDeleteOwner
 - DatasetDeleteAny
 - DatasetAttachmentCreateOwner
 - DatasetAttachmentCreateAny
@@ -59,8 +59,8 @@ This is the list of the permissions methods available for datasets and all their
 - DatasetAttachmentReadAccess
 - DatasetAttachmentReadOwner
 - DatasetAttachmentReadAny
-- DatasetAtatchementUpdateOwner
-- DatasetAtatchementUpdateAny
+- DatasetAttachmentUpdateOwner
+- DatasetAttachmentUpdateAny
 - DatasetAttachmentDeleteOwner
 - DatasetAttachmentDeleteAny
 - DatasetOrigdatablockCreateOwner
@@ -131,7 +131,7 @@ Note, merely for visibility reasons the table has been split. Hierarchically, `O
 | -------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- | ------- |
 | POST | Datasets | _DatasetCreate_ | __no__ | __no__ | Owner, w/o PID<br/>_DatasetCreateOwnerNoPid_ | Owner, w/ PID<br/>_DatasetCreateOwnerWithPid_ | Any<br/>_DatasetCreateAny_ | Any<br/>_DatasetCreateAny_ | __no__ | 
 | POST | Datasets/isValid | _DatasetCreate_ | __no__ | __no__ | Owner, w/o PID<br/>_DatasetCreateOwnerNoPid_ | Owner, W/ PID<br/>_DatasetCreateOwnerWithPid_ | Any<br/>_DatasetCreateAny_ | Any<br/>_DatasetCreateAny_ | __no__ | 
-| GET | Datasets | _DatasetRead_ | Public<br/>_DatasetReadPublic_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Any<br/>_DatasetReadyAny_ | __no__ | 
+| GET | Datasets | _DatasetRead_ | Public<br/>_DatasetReadPublic_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Any<br/>_DatasetReadAny_ | __no__ | 
 | GET | Datasets/fullquery | _DatasetRead_ | Public<br/>_DatasetReadManyPublic_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Any<br/>_DatasetReadAny_ | __no__ | 
 | GET | Datasets/fullfacet | _DatasetRead_ | Public<br/>_DatasetReadManyPublic_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Any<br/>_DatasetReadAny_ | __no__ | 
 | GET | Datasets/metadataKeys | _DatasetRead_ | Public<br/>_DatasetReadManyPublic_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Has Access<br/>_DatasetReadManyAccess_ | Any<br/>_DatasetReadAny_ | __no__ | 
@@ -147,9 +147,9 @@ Note, merely for visibility reasons the table has been split. Hierarchically, `O
 | GET | Datasets/_pid_/thumbnail | _DatasetRead_ | Public<br/>_DatasetReadPublic_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Has Access<br/>_DatasetReadAccess_ | Any<br/>_DatasetReadAny_ | __no__ | 
 | | | | | | | | | |
 | POST | Datasets/_pid_/attachments | _DatasetAttachmentCreate_ | __no__ | __no__ | Owner<br/>_DatasetAttachmentCreateOwner_ | Owner<br/>_DatasetAttachmentCreateOwner_ | Any<br/>_DatasetAttachmentCreateAny_ | Any<br/>_DatasetAttachmentCreateAny_ | __no__ | 
-| GET | Datasets/_pid_/attachments | _DatasetAttachmemntRead_ | Public<br/>_DatasetAttachmentReadPublic_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Any<br/>_DatasetAttachmentReadAny_ | __no__ | 
-| PUT | Datasets/_pid_/attachments/_aid_ | _DatasetAttachmemntUpdate_ | __no__ | __no__ | Owner<br/>_DatasetAttachmentUpdateOwner_ | Owner<br/>_DatasetAttachmentUpdateOwner_ | Owner<br/>_DatasetAttachmentUpdateOwner_ |  Any<br/>_DatasetAttachmentCreateAny_ | __no__ | 
-| DELETE | Datasets/_pid_/attachments/_aid_ | _DatasetAttachmemntDelete_ | __no__ | __no__ | Owner<br/>_DatasetAttachmentDeleteOwner_ | Owner<br/>_DatasetAttachmentDeleteOwner_ | Owner<br/>_DatasetAttachmentDeleteOwner_ | Any<br/>_DatasetAttachmentDeleteAny_ | __no__ | 
+| GET | Datasets/_pid_/attachments | _DatasetAttachmentRead_ | Public<br/>_DatasetAttachmentReadPublic_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Has Access<br/>_DatasetAttachmentReadAccess_ | Any<br/>_DatasetAttachmentReadAny_ | __no__ | 
+| PUT | Datasets/_pid_/attachments/_aid_ | _DatasetAttachmentUpdate_ | __no__ | __no__ | Owner<br/>_DatasetAttachmentUpdateOwner_ | Owner<br/>_DatasetAttachmentUpdateOwner_ | Owner<br/>_DatasetAttachmentUpdateOwner_ |  Any<br/>_DatasetAttachmentCreateAny_ | __no__ | 
+| DELETE | Datasets/_pid_/attachments/_aid_ | _DatasetAttachmentDelete_ | __no__ | __no__ | Owner<br/>_DatasetAttachmentDeleteOwner_ | Owner<br/>_DatasetAttachmentDeleteOwner_ | Owner<br/>_DatasetAttachmentDeleteOwner_ | Any<br/>_DatasetAttachmentDeleteAny_ | __no__ | 
 
 #### OrigDatablock
 | HTTP method | Endpoint | Endpoint Authorization | Anonymous | Authenticated User | Create Dataset Groups | Create Dataset with Pid Groups | Create Dataset Privileged Groups | Admin Groups | Delete Groups | Notes |

--- a/docs/backendconfig/index.md
+++ b/docs/backendconfig/index.md
@@ -20,395 +20,469 @@ All environment variables can be used in the ```.env``` filee. The current sourc
 
 The list is compiled according to the configuration class defined in [_src/config/configuration.ts_](https://github.com/SciCatProject/scicat-backend-next/blob/master/src/config/configuration.ts).
 
-- ADMIN\_GROUPS:  
-  list of groups that have admin priviliges  
-  _default_: ""  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.  
+- ADMIN\_GROUPS:
+  list of groups that have admin priviliges
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.
 
-- DELETE\_GROUPS:  
-  list of groups that are allowed to delete content  
-  _default_: ""  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.  
+- DELETE\_GROUPS:
+  list of groups that are allowed to delete content
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.
 
-- CREATE\_DATASET\_GROUPS:  
-  list of non admin groups that are allowed to create datasets without pid. The pid is assigned by the system. If set to "#all", all users can create a dataset belonging to any of the groups they belong to.    
-  _default_: "#all"  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.  
+- CREATE\_DATASET\_GROUPS:
+  list of non admin groups that are allowed to create datasets without pid. The pid is assigned by the system. If set to "#all", all users can create a dataset belonging to any of the groups they belong to.
+  _default_: "#all"
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.
 
-- CREATE\_DATASET\_WITH\_PID\_GROUPS:  
-  list of non admin groups that are allowed to create datasets with explicit pid. If set to "#all", all users can create a dataset belonging to any of the groups they belong to and with esplicit pid.  
-  If the pid verification is enabled, pid will be validated agains the specification passed.  
-  _default_: ""  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.  
+- CREATE\_DATASET\_WITH\_PID\_GROUPS:
+  list of non admin groups that are allowed to create datasets with explicit pid. If set to "#all", all users can create a dataset belonging to any of the groups they belong to and with esplicit pid.
+  If the pid verification is enabled, pid will be validated agains the specification passed.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.
 
-- CREATE\_DATASET\_PRIVILEGED\_GROUPS:  
-  list of non admin groups that are allowed to create datasets for groups they do not belong to. If set to "#all", all users can create a dataset belonging to any group with explicit pid.  
-  If the pid verification is enabled, pid will be validated agains the specification passed.  
-  _default_: ""  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.  
+- CREATE\_DATASET\_PRIVILEGED\_GROUPS:
+  list of non admin groups that are allowed to create datasets for groups they do not belong to. If set to "#all", all users can create a dataset belonging to any group with explicit pid.
+  If the pid verification is enabled, pid will be validated agains the specification passed.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed.
 
-- PROPOSAL\_GROUPS:  
-  list of non admin groups that are allowed to create and update proposals for groups they do not belong to. If set to "#all", all users can create a dataset belonging to any group with explicit pid.  
-  _default_: ""  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed  
+- PROPOSAL\_GROUPS:
+  list of non admin groups that are allowed to create and update proposals for groups they do not belong to. If set to "#all", all users can create a dataset belonging to any group with explicit pid.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
 
-- SAMPLE\_GROUPS:  
-  list of non admin groups that are allowed to create and update samples for the groups they belong to. If set to "#all", all users can create a dataset belonging to their group.  
-  _default_: ""  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed  
+- SAMPLE\_GROUPS:
+  list of non admin groups that are allowed to create and update samples for the groups they belong to. If set to "#all", all users can create a dataset belonging to their group.
+  _default_: "#all"
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
 
-- SAMPLE\_PRIVILEGED\_GROUPS:  
+- SAMPLE\_PRIVILEGED\_GROUPS:
   list of non admin groups that are allowed to create samples for any groups, but can only update samples belonging to groups they belong to.
-  _default_: ""  
-  _format_: comma separated list of strings. Leading and trailing spaces are trimmed  
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
 
+- POLICY\_GROUPS:
+  list of groups that are allowed to create, read, and update policies. Users in ADMIN\_GROUPS always have this permission regardless of this setting.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
 
-- ACCESS\_GROUPS\_STATIC\_VALUES:  
-  List of groups assigned by default to all users. Used in the vanilla implementation for easy configuration.  
-  If you do not want or need to assign any default group, it should be set to empty string "".  
-  Default value: ""  
-  _format_: Comman separated list of strings. Leading and trailing spaces are trimmed  
-  _example_: "group1,group2,group3,..."  
+- UPDATE\_DATASET\_LIFECYCLE\_GROUPS:
+  list of groups that are allowed to update the lifecycle state of a dataset. Authenticated users not in this list (or ADMIN\_GROUPS) cannot modify lifecycle fields.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- CREATE\_JOB\_PRIVILEGED\_GROUPS:
+  list of groups that are allowed to create jobs for any user or group, regardless of the job configuration's `create.auth` field. Users in this group can also read any job.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- UPDATE\_JOB\_PRIVILEGED\_GROUPS:
+  list of groups that are allowed to update any job, regardless of the job configuration's `update.auth` field. Users in this group can also read any job.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- DELETE\_JOB\_GROUPS:
+  list of groups that are allowed to delete any job. Authenticated users not in this list (or ADMIN\_GROUPS) cannot delete jobs.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- ATTACHMENT\_GROUPS:
+  list of groups that are allowed to create, read, update, and delete attachments belonging to groups they are a member of. If set to "#all", all authenticated users have these permissions.
+  _default_: "#all"
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- ATTACHMENT\_PRIVILEGED\_GROUPS:
+  list of groups that are allowed to create attachments for any owner group, and to read, update, and delete attachments belonging to groups they are a member of or that they have access to.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_DATASET\_GROUPS:
+  list of groups that are allowed to read the change history of datasets. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_PROPOSAL\_GROUPS:
+  list of groups that are allowed to read the change history of proposals. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_SAMPLE\_GROUPS:
+  list of groups that are allowed to read the change history of samples. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_INSTRUMENT\_GROUPS:
+  list of groups that are allowed to read the change history of instruments. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_PUBLISHED\_DATA\_GROUPS:
+  list of groups that are allowed to read the change history of published data records. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_POLICIES\_GROUPS:
+  list of groups that are allowed to read the change history of policies. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_DATABLOCK\_GROUPS:
+  list of groups that are allowed to read the change history of datablocks. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- HISTORY\_ACCESS\_ATTACHMENT\_GROUPS:
+  list of groups that are allowed to read the change history of attachments. Users in ADMIN\_GROUPS always have this access.
+  _default_: ""
+  _format_: comma separated list of strings. Leading and trailing spaces are trimmed
+
+- ACCESS\_GROUPS\_STATIC\_VALUES:
+  List of groups assigned by default to all users. Used in the vanilla implementation for easy configuration.
+  If you do not want or need to assign any default group, it should be set to empty string "".
+  Default value: ""
+  _format_: Comman separated list of strings. Leading and trailing spaces are trimmed
+  _example_: "group1,group2,group3,..."
 
 - ACCESS\_GROUP\_SERVICE\_TOKEN:
-  Access token needed to access the API specified in ACCESS\_GROUP\_SERVICE\_API\_URL, used to retrieve access groups from a third party system.  
-  _format*: string 
+  Access token needed to access the API specified in ACCESS\_GROUP\_SERVICE\_API\_URL, used to retrieve access groups from a third party system.
+  _format*: string
 
-- ACCESS\_GROUP\_SERVICE\_API\_URL:  
-  Well formed url of the service API used to provide access groups. Only one value is allowed.  
-  _format_: string  
+- ACCESS\_GROUP\_SERVICE\_API\_URL:
+  Well formed url of the service API used to provide access groups. Only one value is allowed.
+  _format_: string
   _example_: "https://my.access.group/service/api/url"
-  
-- DOI_PREFIX:  
-  The facility DOI prefix, with trailing slash.  
-  _default_: ""  
-  _format_: string  
 
-- EXPRESS\_SESSION\_SECRET:  
-  Secret used to set up express session.  
-  _default_: ""  
-  _format_: string  
+- DOI_PREFIX:
+  The facility DOI prefix, with trailing slash.
+  _default_: ""
+  _format_: string
 
-- LOGOUT\_URL:  
-  URL specified upon successful logout. It is returned in the json object for the frontend, or third party UI, to be used locally.  
-  _default_: ""  
-  _format_: string  
+- EXPRESS\_SESSION\_SECRET:
+  Secret used to set up express session.
+  _default_: ""
+  _format_: string
 
-- HTTP\_MAX\_REDIRECTS:  
-  Max number of redirects for http requests.  
-  _default_: 5  
-  _format_: integer  
+- LOGOUT\_URL:
+  URL specified upon successful logout. It is returned in the json object for the frontend, or third party UI, to be used locally.
+  _default_: ""
+  _format_: string
 
-- HTTP\_TIMEOUT:  
-  Timeout from http requests in ms.  
-  _default_: 5000  
+- HTTP\_MAX\_REDIRECTS:
+  Max number of redirects for http requests.
+  _default_: 5
   _format_: integer
-  
-- JWT_SECRET:  
-  The secret used to create any JWT token, used for authorization.  
-  _default_: ""  
-  _format_: string  
 
-- JWT\_EXPIRES\_IN:  
-  Expiration time of any JWT token in seconds.  
-  _default_: 3600 (s)  
-  _format_: integer  
+- HTTP\_TIMEOUT:
+  Timeout from http requests in ms.
+  _default_: 5000
+  _format_: integer
 
-- JWT\_NEVER\_EXPIRES:  
-  Length of time that the never expiring jwt token will last.  
-  _default_: 100y  
-  _format_: string as in number of years  
+- JWT_SECRET:
+  The secret used to create any JWT token, used for authorization.
+  _default_: ""
+  _format_: string
 
-- LDAP\_URL:  
-  Full URI (including port) of your local LDAP server, if this is your selected authentication method.  
-  _default_: No default  
-  _example_: ldaps://ldap.server.com:636/   
-  _format_: string  
+- JWT\_EXPIRES\_IN:
+  Expiration time of any JWT token in seconds.
+  _default_: 3600 (s)
+  _format_: integer
 
-- LDAP\_BIND\_DN:  
-  Bind DN to access information on your LDAP server.  
-  _default_: No default  
-  _format_: string  
+- JWT\_NEVER\_EXPIRES:
+  Length of time that the never expiring jwt token will last.
+  _default_: 100y
+  _format_: string as in number of years
 
-- LDAP\_BIND\_CREDENTIALS:  
-  Credentials associated with your bind DN to acccess your LDAP server.  
-  _default_: No default  
-  _format_: string  
+- LDAP\_URL:
+  Full URI (including port) of your local LDAP server, if this is your selected authentication method.
+  _default_: No default
+  _example_: ldaps://ldap.server.com:636/
+  _format_: string
 
-- LDAP\_SEARCH\_BASE:  
-  Search base for your LDAP server.  
-  _default_: No default   
-  _format_: string  
+- LDAP\_BIND\_DN:
+  Bind DN to access information on your LDAP server.
+  _default_: No default
+  _format_: string
 
-- LDAP\_SEARCH\_FILTER:  
-  Search filter for you LDAP server.  
-  _default_: No default  
-  _format_: string   
-  _example_: "(LDAPUsername={{username}})"  
+- LDAP\_BIND\_CREDENTIALS:
+  Credentials associated with your bind DN to acccess your LDAP server.
+  _default_: No default
+  _format_: string
 
-- LDAP\_MODE:  
-  type of ldap server we are communicating with  
-  **_NEEDS TO BE UPDATED. Not sure which other values are accepted_**  
-  _default_: ad  
-  _format_: string  
-  _acceptable values_: ad  
-  
-- LDAP\_EXTERNAL\_ID:  
-  LDAP matching field that provides the external id  
-  _default_: sAMAccountName  
-  _format_: string  
+- LDAP\_SEARCH\_BASE:
+  Search base for your LDAP server.
+  _default_: No default
+  _format_: string
 
-- LDAP\_USERNAME:  
-  LDAP field providing the username  
-  _default_: displayName  
-  _format_: string  
+- LDAP\_SEARCH\_FILTER:
+  Search filter for you LDAP server.
+  _default_: No default
+  _format_: string
+  _example_: "(LDAPUsername={{username}})"
 
-- OIDC\_ISSUER:  
-  Full URL of your OIDC identity provider  
-  _default_: No default  
-  _format_: string  
-  _example_: "https://identity.your.facility/your/realm"  
+- LDAP\_MODE:
+  type of ldap server we are communicating with
+  **_NEEDS TO BE UPDATED. Not sure which other values are accepted_**
+  _default_: ad
+  _format_: string
+  _acceptable values_: ad
 
-- OIDC\_CLIENT\_ID:  
-  Client id used to convert OIDC code to OIDC token. This is assigned in the OIDC service when the token is generated  
-  _default_: No default  
-  _format_: string  
-  _example_: "scicat"  
+- LDAP\_EXTERNAL\_ID:
+  LDAP matching field that provides the external id
+  _default_: sAMAccountName
+  _format_: string
 
-- OIDC\_CLIENT\_SECRET:   
-  Token used to convert OIDC code to OIDC token. This is assigned in the OIDC service when the token is generated  
-  _example_: "90f1268..."  
+- LDAP\_USERNAME:
+  LDAP field providing the username
+  _default_: displayName
+  _format_: string
 
-- OIDC\_CALLBACK\_URL:  
-  URL of the endpoint that is called when the authentication has been executed with the OIDC service.   
-  _default_: No default   
-  _format_: string    
-  _example_: "http://localhost:3000/api/v3/oidc/callback"  
+- OIDC\_ISSUER:
+  Full URL of your OIDC identity provider
+  _default_: No default
+  _format_: string
+  _example_: "https://identity.your.facility/your/realm"
 
-- OIDC\_SCOPE:  
-  Information returned by the OIDC service together with token  
-  _default_: No default  
-  _format_: string   
-  _example_: "openid profile email"  
+- OIDC\_CLIENT\_ID:
+  Client id used to convert OIDC code to OIDC token. This is assigned in the OIDC service when the token is generated
+  _default_: No default
+  _format_: string
+  _example_: "scicat"
 
-- OIDC\_SUCCESS\_URL:  
-  Frontend URL that the user is directed to after a successful authentication. It must be a valid frontend URL.  
-  _default_: No default  
-  _format_: string  
-  _example_: "http://localhost:3000/Datasets"  
+- OIDC\_CLIENT\_SECRET:
+  Token used to convert OIDC code to OIDC token. This is assigned in the OIDC service when the token is generated
+  _example_: "90f1268..."
 
-- OIDC\_ACCESS\_GROUPS:  
-  field used to retrieve access groups from the OIDC service. It is not used in the vanilla implementation.  
-  _default_: No default  
-  _format_: string  
-  _example_: "access_groups"  
+- OIDC\_CALLBACK\_URL:
+  URL of the endpoint that is called when the authentication has been executed with the OIDC service.
+  _default_: No default
+  _format_: string
+  _example_: "http://localhost:3000/api/v3/oidc/callback"
 
-- OIDC\_ACCESS\_GROUPS\_PROPERTY:  
-  name of the OIDC property used to retrieve the users groups from OIDC.  
-  _default_: none  
-  _format_: string  
+- OIDC\_SCOPE:
+  Information returned by the OIDC service together with token
+  _default_: No default
+  _format_: string
+  _example_: "openid profile email"
 
-- OIDC\_AUTO\_LOGOUT:  
-  if enabled, when login out from SciCat, we logout from OIDC also.  
-  _default_: false  
-  _format_: boolean  
+- OIDC\_SUCCESS\_URL:
+  Frontend URL that the user is directed to after a successful authentication. It must be a valid frontend URL.
+  _default_: No default
+  _format_: string
+  _example_: "http://localhost:3000/Datasets"
 
-- OIDC\_RETURN\_URL:  
-  URL the user is redirected after a successful logout  
-  _default_: none  
-  _format_: string  
+- OIDC\_ACCESS\_GROUPS:
+  field used to retrieve access groups from the OIDC service. It is not used in the vanilla implementation.
+  _default_: No default
+  _format_: string
+  _example_: "access_groups"
 
-- LOGBOOK\_ENABLED:  
-  Flag to enable/disable the Logbook endpoints.  
-  accept values: "yes", "no"  
-  _default_: no   
-  _format_: string  
+- OIDC\_ACCESS\_GROUPS\_PROPERTY:
+  name of the OIDC property used to retrieve the users groups from OIDC.
+  _default_: none
+  _format_: string
 
-- LOGBOOK\_BASE\_URL:  
-  The base URL to the SciChat wrapper API. Only required if Logbook is enabled.  
-  _default_: "http://localhost:3030/scichatapi"  
-  _format_: string  
+- OIDC\_AUTO\_LOGOUT:
+  if enabled, when login out from SciCat, we logout from OIDC also.
+  _default_: false
+  _format_: boolean
 
-- LOGBOOK\_USERNAME:  
-  The username used to authenticate to the SciChat wrapper API. Only required if Logbook is enabled.  
-  _default_: No default  
-  _format_: string  
+- OIDC\_RETURN\_URL:
+  URL the user is redirected after a successful logout
+  _default_: none
+  _format_: string
 
-- LOGBOOK\_PASSWORD:  
-  The password used to authenticate to the SciChat wrapper API. Only required if Logbook is enabled.  
-  _default_: No default  
-  _format_: string  
+- LOGBOOK\_ENABLED:
+  Flag to enable/disable the Logbook endpoints.
+  accept values: "yes", "no"
+  _default_: no
+  _format_: string
 
-- METADATA\_KEYS\_RETURN\_LIMIT:  
-  The maximum number of keys returned by the `/Datasets/metadataKeys` endpoint.  
-  _default_: No default  
-  _format_: integer  
+- LOGBOOK\_BASE\_URL:
+  The base URL to the SciChat wrapper API. Only required if Logbook is enabled.
+  _default_: "http://localhost:3030/scichatapi"
+  _format_: string
 
-- METADATA\_PARENT\_INSTANCES\_RETURN\_LIMIT:  
-  The maximum number of Datasets used to extract metadata keys in the `/Datasets/metadataKeys` endpoint.  
-  _default_: No default  
-  _format_: integer  
+- LOGBOOK\_USERNAME:
+  The username used to authenticate to the SciChat wrapper API. Only required if Logbook is enabled.
+  _default_: No default
+  _format_: string
 
-- MONGODB\_URI:  
-  The URI for your MongoDB instance.  
-  _default_: No default  
-  _format_: string "mongodb://<USERNAME>:<PASSWORD>@<HOST>:27017/<DB_NAME>"  
-  
-- OAI\_PROVIDER\_ROUTE:  
-  URI to OAI provider, which is used in the `/publisheddata/:id/resync` endpoint.  
-  _default_: no default  
-  _format_: string  
+- LOGBOOK\_PASSWORD:
+  The password used to authenticate to the SciChat wrapper API. Only required if Logbook is enabled.
+  _default_: No default
+  _format_: string
 
-- PID\_PREFIX:  
-  The facility PID prefix, with trailing slash.  
-  _default_: no default  
-  _format_: string  
+- METADATA\_KEYS\_RETURN\_LIMIT:
+  The maximum number of keys returned by the `/Datasets/metadataKeys` endpoint.
+  _default_: No default
+  _format_: integer
 
-- PUBLIC\_URL\_PREFIX:  
-  The base URL to the facility Landing Page.  
-  _default_: No default  
-  _format_: string  
-  _example_: "https://doi.ess.eu/detail/"  
+- METADATA\_PARENT\_INSTANCES\_RETURN\_LIMIT:
+  The maximum number of Datasets used to extract metadata keys in the `/Datasets/metadataKeys` endpoint.
+  _default_: No default
+  _format_: integer
 
-- PORT:  
-  The port on which the backend listen on.  
-  _default_: 3000  
-  _format_: integer  
+- MONGODB\_URI:
+  The URI for your MongoDB instance.
+  _default_: No default
+  _format_: string "mongodb://<USERNAME>:<PASSWORD>@<HOST>:27017/<DB_NAME>"
 
-- RABBITMQ\_ENABLED:  
-  Flag to enable/disable RabbitMQ consumer.  
-  accepted values: "yes", "no"  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no  
-  _format_: string  
-  
-- RABBITMQ\_HOSTNAME:  
-  The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled.  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no default  
-  _default_: string  
+- OAI\_PROVIDER\_ROUTE:
+  URI to OAI provider, which is used in the `/publisheddata/:id/resync` endpoint.
+  _default_: no default
+  _format_: string
 
-- RABBITMQ\_USERNAME:  
-  The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled.  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no default  
-  _format_: string  
+- PID\_PREFIX:
+  The facility PID prefix, with trailing slash.
+  _default_: no default
+  _format_: string
 
-- RABBITMQ\_PASSWORD:  
+- PUBLIC\_URL\_PREFIX:
+  The base URL to the facility Landing Page.
+  _default_: No default
+  _format_: string
+  _example_: "https://doi.ess.eu/detail/"
+
+- PORT:
+  The port on which the backend listen on.
+  _default_: 3000
+  _format_: integer
+
+- RABBITMQ\_ENABLED:
+  Flag to enable/disable RabbitMQ consumer.
+  accepted values: "yes", "no"
+  _deprecated_. Will be removed in future releases.
+  _default_: no
+  _format_: string
+
+- RABBITMQ\_HOSTNAME:
+  The hostname of the RabbitMQ message broker. Only required if RabbitMQ is enabled.
+  _deprecated_. Will be removed in future releases.
+  _default_: no default
+  _default_: string
+
+- RABBITMQ\_USERNAME:
+  The username used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is enabled.
+  _deprecated_. Will be removed in future releases.
+  _default_: no default
+  _format_: string
+
+- RABBITMQ\_PASSWORD:
   The password used to authenticate to the RabbitMQ message broker. Only required if RabbitMQ is
-  enabled.  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no default  
-  _format_: string  
+  enabled.
+  _deprecated_. Will be removed in future releases.
+  _default_: no default
+  _format_: string
 
-- REGISTER\_DOI\_URI:  
-  URI to the organization that registers the facilities DOIs.  
-  _default_: no default  
-  _format_: string  
-  _example_: "https://mds.test.datacite.org/doi"  
+- REGISTER\_DOI\_URI:
+  URI to the organization that registers the facilities DOIs.
+  _default_: no default
+  _format_: string
+  _example_: "https://mds.test.datacite.org/doi"
 
-- REGISTER\_METADATA\_URI:  
-  URI to the organization that registers the facilities published data metadata.  
-  _default_: no default  
-  _format_: string  
-  _example_: ="https://mds.test.datacite.org/metadata"  
+- REGISTER\_METADATA\_URI:
+  URI to the organization that registers the facilities published data metadata.
+  _default_: no default
+  _format_: string
+  _example_: ="https://mds.test.datacite.org/metadata"
 
 - DOI\_USERNAME:
-  Username used to authenticate on the DOI site  
-  _default_: no default  
-  _format_: string  
+  Username used to authenticate on the DOI site
+  _default_: no default
+  _format_: string
 
-- DOI\_PASSWORD:  
-  Password used to authenticate on the DOI site  
-  _default_: no default  
-  _format_: string  
+- DOI\_PASSWORD:
+  Password used to authenticate on the DOI site
+  _default_: no default
+  _format_: string
 
-- SITE:  
-  The name of your site.  
-  _default_: no default  
-  _format_: string  
+- SITE:
+  The name of your site.
+  _default_: no default
+  _format_: string
 
-- SMTP\_HOST:  
-  Host of SMTP server.  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no default  
-  _format_: string  
+- SMTP\_HOST:
+  Host of SMTP server.
+  _deprecated_. Will be removed in future releases.
+  _default_: no default
+  _format_: string
 
-- SMTP\_MESSAGE\_FROM:  
-  Email address that emails should be sent from.  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no default  
-  _format_: string, email  
+- SMTP\_MESSAGE\_FROM:
+  Email address that emails should be sent from.
+  _deprecated_. Will be removed in future releases.
+  _default_: no default
+  _format_: string, email
 
-- SMTP\_PORT:  
-  Port of SMTP server.  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no default  
-  _format_: string  
+- SMTP\_PORT:
+  Port of SMTP server.
+  _deprecated_. Will be removed in future releases.
+  _default_: no default
+  _format_: string
 
-- SMTP\_SECURE:  
-  Secure of SMTP server.  
-  _deprecated_. Will be removed in future releases.  
-  _default_: no default  
-  _format_: string  
+- SMTP\_SECURE:
+  Secure of SMTP server.
+  _deprecated_. Will be removed in future releases.
+  _default_: no default
+  _format_: string
 
-- POLICY\_PUBLICATION\_SHIFT:  
-  Number of years that needs to elapse before the dataset is made publicly acceessible  
-  _default_: 3  
-  _format_: integer  
+- POLICY\_PUBLICATION\_SHIFT:
+  Number of years that needs to elapse before the dataset is made publicly acceessible
+  _default_: 3
+  _format_: integer
 
-- POLICY\_RETENTION\_SHIFT:  
-  Number of years that the datasets are kept online before are archived or deleted. A negative value means that they are never archived/deleted  
-  _default_: -1  
-  _format_: integer  
+- POLICY\_RETENTION\_SHIFT:
+  Number of years that the datasets are kept online before are archived or deleted. A negative value means that they are never archived/deleted
+  _default_: -1
+  _format_: integer
 
-- ELASTICSEARCH\_ENABLED:  
-  Flag to enable/disable the ElasticSearch service  
-  accept values: "yes", "no"  
-  _default_: no default  
-  _format_: string  
+- ELASTICSEARCH\_ENABLED:
+  Flag to enable/disable the ElasticSearch service
+  accept values: "yes", "no"
+  _default_: no default
+  _format_: string
 
-- ES\_HOST:  
-  The base URL to the Elasticsearch cluster. Use `http` if xpack.security is disabled  
-  _default_: no default  
-  _format_: string   
-  _example_: "https://localhost:9200" or "http://localhost:9200"  
+- ES\_HOST:
+  The base URL to the Elasticsearch cluster. Use `http` if xpack.security is disabled
+  _default_: no default
+  _format_: string
+  _example_: "https://localhost:9200" or "http://localhost:9200"
 
-- MONGODB\_COLLECTION:  
-  Collection name to be mapped into specified Elasticsearch index  
-  _default_: no default  
-  _format_: string  
- 
-- ES\_MAX\_RESULT:   
-  Maximum records can be indexed into Elasticsearch.  
-  _default_: 10000  
-  _format_: number  
+- MONGODB\_COLLECTION:
+  Collection name to be mapped into specified Elasticsearch index
+  _default_: no default
+  _format_: string
 
-- ES\_FIELDS\_LIMIT:   
-  The total number of fields in an index.  
-  _default_: 1000  
-  _format_: number  
+- ES\_MAX\_RESULT:
+  Maximum records can be indexed into Elasticsearch.
+  _default_: 10000
+  _format_: number
 
-- ES\_INDEX:  
-  The total number of fields in an index.  
-  _default_: no default  
-  _format_: string  
+- ES\_FIELDS\_LIMIT:
+  The total number of fields in an index.
+  _default_: 1000
+  _format_: number
 
-- ES\_REFRESH:  
-  The total number of fields in an index.  
-  accept values: true, false, "wait_for"  
-  _default_: false  
-  _format_: boolean or string  
+- ES\_INDEX:
+  The total number of fields in an index.
+  _default_: no default
+  _format_: string
 
-- ES\_USERNAME:  
-  Elasticsearch cluster username.  
-  _default_: no default, optional.  
-  _format_: string  
+- ES\_REFRESH:
+  The total number of fields in an index.
+  accept values: true, false, "wait_for"
+  _default_: false
+  _format_: boolean or string
 
-- ELASTIC\_PASSWORD:   
-  Elasticsearch cluster password.  
-  _default_: no default.  
-  _format_: string  
+- ES\_USERNAME:
+  Elasticsearch cluster username.
+  _default_: no default, optional.
+  _format_: string
+
+- ELASTIC\_PASSWORD:
+  Elasticsearch cluster password.
+  _default_: no default.
+  _format_: string
 
 ## Environment Variables as now
 ```
@@ -458,14 +532,27 @@ DATASET_CREATION_VALIDATION_REGEX="^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][
 
 ADMIN_GROUPS=""
 DELETE_GROUPS=""
-CREATE_DATASET_GROUPS="all"
+CREATE_DATASET_GROUPS="#all"
 CREATE_DATASET_WITH_PID_GROUPS=""
 CREATE_DATASET_PRIVILEGED_GROUPS=""
-CREATE_JOB_GROUPS=""
-UPDATE_JOB_GROUPS=""
+UPDATE_DATASET_LIFECYCLE_GROUPS=""
+CREATE_JOB_PRIVILEGED_GROUPS=""
+UPDATE_JOB_PRIVILEGED_GROUPS=""
+DELETE_JOB_GROUPS=""
 SAMPLE_PRIVILEGED_GROUPS="sampleingestor"
 SAMPLE_GROUPS="group1"
 PROPOSAL_GROUPS=""
+POLICY_GROUPS=""
+ATTACHMENT_GROUPS="#all"
+ATTACHMENT_PRIVILEGED_GROUPS=""
+HISTORY_ACCESS_DATASET_GROUPS=""
+HISTORY_ACCESS_PROPOSAL_GROUPS=""
+HISTORY_ACCESS_SAMPLE_GROUPS=""
+HISTORY_ACCESS_INSTRUMENT_GROUPS=""
+HISTORY_ACCESS_PUBLISHED_DATA_GROUPS=""
+HISTORY_ACCESS_POLICIES_GROUPS=""
+HISTORY_ACCESS_DATABLOCK_GROUPS=""
+HISTORY_ACCESS_ATTACHMENT_GROUPS=""
 
 ACCESS_GROUPS_GRAPHQL_ENABLED=true
 ACCESS_GROUP_SERVICE_TOKEN=""
@@ -506,7 +593,7 @@ FRONTEND_THEME_FILE="src/config/frontend.theme.json"
 ### How to configure to connect the backend to other services
 In [scicatlive](https://www.scicatproject.org/scicatlive/latest/services/backend/) you find documentation on how to integrate your SciCat system with services providing identities, (e.g. KeyCloak) and authentication (OpenLDAP).
 
-### How to configure DOI minting 
+### How to configure DOI minting
 In SciCat one can publish selected datasets that triggers a DOI minting process. Find [here](../datasets/Publishing.md) a short introduction on SciCats Published Data class. Instructions how to configure this DOI minting service and in addition make datasets publicly via APIs follow [this Link.](dois.md)
 
 


### PR DESCRIPTION
Add missing variables: POLICY_GROUPS, UPDATE_DATASET_LIFECYCLE_GROUPS, CREATE_JOB_PRIVILEGED_GROUPS, UPDATE_JOB_PRIVILEGED_GROUPS, DELETE_JOB_GROUPS, ATTACHMENT_GROUPS, ATTACHMENT_PRIVILEGED_GROUPS, and all eight HISTORY_ACCESS_*_GROUPS variables.

Fix incorrect names CREATE_JOB_GROUPS/UPDATE_JOB_GROUPS in the example block (should be CREATE_JOB_PRIVILEGED_GROUPS/UPDATE_JOB_PRIVILEGED_GROUPS), correct CREATE_DATASET_GROUPS default from "all" to "#all", and correct SAMPLE_GROUPS default from "" to "#all".

Extend authorization.md with the new groups in the permissions table and a new History Access Groups section.

Trim trailing whitespace.